### PR TITLE
remove print statement from library in compress_to_jpg

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -313,7 +313,6 @@ impl<O: AsRef<Path>, D: AsRef<Path>> Compressor<O, D> {
             current_file = self.original_path.as_ref().to_path_buf();
         }
 
-        print!("{}", current_file.to_str().unwrap());
         let image_file = image::open(&current_file)?;
         let width = image_file.width();
         let height = image_file.height();


### PR DESCRIPTION
libraries should generally not print to stdout, i hope you can remove this line. thanks