### PR TITLE
fix: compress to jpg

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -264,17 +264,14 @@ impl<O: AsRef<Path>, D: AsRef<Path>> Compressor<O, D> {
         let mut file = BufWriter::new(File::create(&target_file)?);
         file.write_all(&compressed_img_data)?;
 
+        // Delete the source file when the flag is true.
         match converted_file {
-            Some(c) => {
-                fs::remove_file(c)?;
+            Some(_) => {
+                if self.delete_source {
+                    fs::remove_file(&self.source_path)?;
+                }
             }
             None => (),
-        }
-
-        // Delete the source file when the flag is true.
-        match self.delete_source {
-            true => fs::remove_file(&self.source_path)?,
-            false => (),
         }
 
         Ok(target_file)

--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -167,7 +167,6 @@ impl<O: AsRef<Path>, D: AsRef<Path>> Compressor<O, D> {
             )?;
             line += 1;
         }
-        
 
         let compressed = comp.finish()?;
         Ok(compressed)

--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -122,16 +122,7 @@ impl<O: AsRef<Path>, D: AsRef<Path>> Compressor<O, D> {
     fn convert_to_jpg(&self) -> Result<PathBuf, Box<dyn Error>> {
         let img = image::open(&self.source_path)?;
         let stem = self.source_path.as_ref().file_stem().unwrap();
-        let mut new_path = match self.source_path.as_ref().parent() {
-            Some(s) => s,
-            None => {
-                return Err(Box::new(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    "Cannot get parent directory!",
-                )))
-            }
-        }
-        .join(stem);
+        let mut new_path = self.dest_path.as_ref().join(stem);
         new_path.set_extension("jpg");
         img.save(&new_path)?;
 


### PR DESCRIPTION
I discovered 2 mishaps in the `compress_to_jpg` function:

1. The source file was deleted whether or not the `delete_source` flag was set
2. The destination file is placed in a parent dir, which isn't nescessary

