### PR TITLE
guess-image-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "image_compressor"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "colorgrad",
  "crossbeam-queue",


### PR DESCRIPTION
Sometimes you have to guess the image format to compress with less failures. People could manually change the file extension and provide wrong image format and the compression could fail. This will prevent that edge case.